### PR TITLE
Prepare null value handling in aggregators [WIP Do not merge]

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/COWList.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/COWList.java
@@ -17,7 +17,6 @@
 package io.warp10.continuum.gts;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Comparator;

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -2384,14 +2384,14 @@ public class GTSHelper {
           if (null != gts.locations) {
             parms[4] = new COWList(gts.locations, currentBucketStartPosition, count);
           } else {
-            parms[4] = new ReadOnlyConstantList(count, Double.NaN);
+            parms[4] = null;
           }
 
           // elevations list
           if (null != gts.elevations) {
             parms[5] = new COWList(gts.elevations, currentBucketStartPosition, count);
           } else {
-            parms[5] = new ReadOnlyConstantList(count, Double.NaN);
+            parms[5] = null;
           }
 
           // values

--- a/warp10/src/main/java/io/warp10/script/WarpScriptAggregatorOnListsFunction.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptAggregatorOnListsFunction.java
@@ -22,8 +22,9 @@ package io.warp10.script;
  * 
  * This is the base interface for Mappers, Reducers, Bucketizers and Binary Ops
  *
- * WarpScriptAggregatorFunction apply() arguments are arrays of arrays.
- * WarpScriptAggregatorOnListsFunction applyOnSubLists() arguments are ready to use on a stack.
+ * WarpScriptAggregatorFunction apply() argument is an array of arrays.
+ * WarpScriptAggregatorOnListsFunction applyOnSubLists() argument is similar except that data (ticks, locations, elevs, values) are either COWLists or null if empty.
+ *
  */
 public interface WarpScriptAggregatorOnListsFunction {
   public Object applyOnSubLists(Object[] subLists) throws WarpScriptException;

--- a/warp10/src/main/java/io/warp10/script/WarpScriptAggregatorOnListsFunction.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptAggregatorOnListsFunction.java
@@ -26,5 +26,5 @@ package io.warp10.script;
  * WarpScriptAggregatorOnListsFunction applyOnSubLists() arguments are ready to use on a stack.
  */
 public interface WarpScriptAggregatorOnListsFunction {
-  public Object applyOnSubLists(Object[] sublists) throws WarpScriptException;
+  public Object applyOnSubLists(Object[] subLists) throws WarpScriptException;
 }

--- a/warp10/src/main/java/io/warp10/script/functions/MACROMAPPER.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MACROMAPPER.java
@@ -17,6 +17,7 @@
 package io.warp10.script.functions;
 
 import com.geoxp.GeoXPLib;
+import io.warp10.continuum.gts.COWList;
 import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptAggregatorOnListsFunction;
@@ -30,7 +31,6 @@ import io.warp10.script.WarpScriptStack.Macro;
 import io.warp10.script.WarpScriptStackFunction;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -147,7 +147,65 @@ public class MACROMAPPER extends NamedWarpScriptFunction implements WarpScriptSt
     public Object applyOnSubLists(Object[] subLists) throws WarpScriptException {
 
       // Push arguments onto the stack
-      stack.push(Arrays.asList(subLists));
+      List<Object> params = new ArrayList<Object>(8);
+
+      // tick of computation, names, labels, ticks
+      for (int i = 0; i < 4; i++) {
+        params.add(subLists[i]);
+      }
+
+      // locations need to be converted
+      if (subLists[4] instanceof COWList) {
+        COWList locations = (COWList) subLists[4];
+
+        ArrayList<Double> lats = new ArrayList<Double>(locations.size());
+        ArrayList<Double> lons = new ArrayList<Double>(locations.size());
+
+        for (int i = 0; i < locations.size(); i++) {
+          Long location = (Long) locations.get(i);
+          if (GeoTimeSerie.NO_LOCATION == location) {
+            lats.add(Double.NaN);
+            lons.add(Double.NaN);
+          } else {
+            double[] latlon = GeoXPLib.fromGeoXPPoint(location);
+            lats.add(latlon[0]);
+            lons.add(latlon[1]);
+          }
+        }
+        params.add(lats);
+        params.add(lons);
+
+      } else {
+        // in this case, it is a readOnlyConstantList with value Double.NaN
+        params.add(subLists[4]);
+        params.add(subLists[4]);
+      }
+
+      // elevations
+      if (subLists[5] instanceof COWList) {
+        COWList elevCOWs = (COWList) subLists[5];
+
+        ArrayList<Object> elevs = new ArrayList<Object>(elevCOWs.size());
+        for (int i = 0; i < elevCOWs.size(); i++) {
+          if (GeoTimeSerie.NO_ELEVATION == (Long) elevCOWs.get(i)) {
+            elevs.add(Double.NaN);
+          } else {
+            elevs.add(elevCOWs.get(i));
+          }
+        }
+
+        params.add(elevs);
+
+      } else {
+        // in this case, it is a readOnlyConstantList with value Double.NaN
+        params.add(subLists[5]);
+      }
+
+      // values
+      params.add(subLists[6]);
+
+      // push and exec
+      stack.push(params);
 
       // Execute macro
       stack.exec(this.macro);

--- a/warp10/src/main/java/io/warp10/script/functions/MACROMAPPER.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MACROMAPPER.java
@@ -19,6 +19,7 @@ package io.warp10.script.functions;
 import com.geoxp.GeoXPLib;
 import io.warp10.continuum.gts.COWList;
 import io.warp10.continuum.gts.GeoTimeSerie;
+import io.warp10.continuum.gts.ReadOnlyConstantList;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptAggregatorOnListsFunction;
 import io.warp10.script.WarpScriptBucketizerFunction;
@@ -155,7 +156,7 @@ public class MACROMAPPER extends NamedWarpScriptFunction implements WarpScriptSt
       }
 
       // locations need to be converted
-      if (subLists[4] instanceof COWList) {
+      if (null != subLists[4]) {
         COWList locations = (COWList) subLists[4];
 
         ArrayList<Double> lats = new ArrayList<Double>(locations.size());
@@ -177,12 +178,13 @@ public class MACROMAPPER extends NamedWarpScriptFunction implements WarpScriptSt
 
       } else {
         // in this case, it is a readOnlyConstantList with value Double.NaN
-        params.add(subLists[4]);
-        params.add(subLists[4]);
+        Object o = new ReadOnlyConstantList(((List) subLists[3]).size(), Double.NaN);
+        params.add(o);
+        params.add(o);
       }
 
       // elevations
-      if (subLists[5] instanceof COWList) {
+      if (null != subLists[5]) {
         COWList elevCOWs = (COWList) subLists[5];
 
         ArrayList<Object> elevs = new ArrayList<Object>(elevCOWs.size());
@@ -198,7 +200,7 @@ public class MACROMAPPER extends NamedWarpScriptFunction implements WarpScriptSt
 
       } else {
         // in this case, it is a readOnlyConstantList with value Double.NaN
-        params.add(subLists[5]);
+        params.add(new ReadOnlyConstantList(((List) subLists[3]).size(), Double.NaN));
       }
 
       // values


### PR DESCRIPTION
This PR is a proposition to be discussed.
We defer the conversions of locations and elevations from GTSHelper to MACROMAPPER.

This prepares the ground for:
1. A sub COW GTS structure that will hold the subarrays instead of an array of sublists
2. Replace WarpScriptAggregatorOnSubLists into WarpScriptAggregatorOnSubGTS
3. GTSHelper will create a sub COW GTS if it sees a WarpScriptAggregatorOnSubGTS -> fringe case will now be handled by the apply method of the aggregator instead of having to be implicit between GTSHelper and MACROMAPPER (and all subsequent functions that will use it)
4. Proposition: WarpScriptAggregatorFunction extends WarpScriptAggregatorOnSubGTS with a default method implementation to guarantee backward support (applyOnSubGts will fall back to apply) -> every new function will only have to implement applyOnSubGts
5. We can then remove the case in GTSHelper.bucketize when it sees a WarpScriptAggregatorFunction
6. In a next PR, null handling functions will only need to wrap WarpScriptAggregatorOnSubGTS, to effectively alter the COW lists contained in the sub GTS prior to apply -> same goes for STRICTMAPPER and any other function taking an aggregator as argument

